### PR TITLE
Change handle edit book

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,8 +1,13 @@
 import axios from "axios";
-import { LoginModel, RegisterModel, TokenModel, UserModel } from "../models/user";
-import { generalError, generalPass } from '../helpers/warnings/general'
-import registerStore from '../store/User';
-import authStore from '../store/Auth';
+import {
+  LoginModel,
+  RegisterModel,
+  TokenModel,
+  UserModel,
+} from "../models/user";
+import { generalError, generalPass } from "../helpers/warnings/general";
+import registerStore from "../store/User";
+import authStore from "../store/Auth";
 
 const path = process.env.REACT_APP_PRO_MODE;
 
@@ -11,17 +16,17 @@ export async function getLogin(data: LoginModel): Promise<TokenModel> {
   try {
     let response = await axios.post<TokenModel>(path + "auth/token", data);
     response.data.isAuthenticated = true;
-		generalPass('Autenticación completa');
-		authStore.setState(response.data);
+    generalPass("Autenticación completa");
+    authStore.setState(response.data);
     return response.data;
   } catch (error) {
-		let response = error.response.data.detail;
-		generalError(response);
-		return {
-			access_token: '',
-			refresh_token: '',
-			isAuthenticated: false
-		};
+    let response = error.response.data.detail;
+    generalError(response);
+    return {
+      access_token: "",
+      refresh_token: "",
+      isAuthenticated: false,
+    };
   }
 }
 
@@ -32,15 +37,17 @@ export async function refreshToken(token: string): Promise<string> {
   return response.data;
 }
 
-export async function postRegister(data: RegisterModel): Promise<UserModel | Error> {
-	try {
-  	let response = await axios.post<UserModel>(path + "user/", data);
-		registerStore.setState(response.data);
-		generalPass('Registro completo');
-  	return response.data;
-	} catch (error) {
-		let response = error.response.data.detail;
-		generalError(response);
-		return new Error(error);
-	}
+export async function postRegister(
+  data: RegisterModel
+): Promise<UserModel | Error> {
+  try {
+    let response = await axios.post<UserModel>(path + "user/", data);
+    registerStore.setState(response.data);
+    generalPass("Registro completo");
+    return response.data;
+  } catch (error) {
+    let response = error.response.data.detail;
+    generalError(response);
+    return new Error(error);
+  }
 }

--- a/src/helpers/warnings/general.ts
+++ b/src/helpers/warnings/general.ts
@@ -26,4 +26,3 @@ export function generalPass(message: string) {
     isPermanent: false,
   });
 }
-

--- a/src/views/Profile.tsx
+++ b/src/views/Profile.tsx
@@ -40,10 +40,8 @@ function Profile() {
 
   const handleEditBook = async (book_id: number) => {
     setEditing(book_id);
-    let book = books_for_sale.reduce((acc, curr) =>
-      curr.id === book_id ? curr : acc
-    );
-    if (book !== null) {
+    let book = books_for_sale.find((book) => book.id === book_id);
+    if (book !== undefined) {
       setCurrentBook(book);
     }
   };


### PR DESCRIPTION
Change the way the edit book handler looks for the book that is being edited.
Previously it looked for it with a reducer in the books array: 
```javascript
let book = books_for_sale.reduce((acc, curr) =>
  curr.id === book_id ? curr : acc
);
```
This is inefficient because it traverses the whole array even if it already found the book.

The new implementation stops when the book is found:
```javascript
let book = books_for_sale.find((book) => book.id === book_id);
```